### PR TITLE
Update README base URL note

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ npm ci
 npm run dev
 ```
 
-`npm run build` で本番用ビルドを作成します。
+`npm run build` で本番用ビルドを作成します。ビルド後のファイルは `/RubicSolver/`
+をベースとしたパスで出力されます。ローカルサーバーでも同じパスで公開するか、
+`vite.config.ts` の `base` オプションを変更して確認してください。
 
 このプロジェクトは [MIT License](LICENSE) の下で公開されています。
 

--- a/rubicsolver-app/README.md
+++ b/rubicsolver-app/README.md
@@ -14,3 +14,7 @@ npm run dev
 ```bash
 npm run build
 ```
+
+本番ビルドは `/RubicSolver/` を基点に生成されます。ローカル環境で確認する場合は
+同じパスでサーバーを立てるか、`vite.config.ts` の `base` を変更して調整してくださ
+い。


### PR DESCRIPTION
## Summary
- clarify production base path in README
- add same note to rubicsolver-app README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846d3e07cdc8321b8468c9cd27fc100