### PR TITLE
Use VITE_BASE_PATH in Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ npm ci
 npm run dev
 ```
 
-`npm run build` で本番用ビルドを作成します。ビルド後のファイルは `/RubicSolver/`
-をベースとしたパスで出力されます。ローカルサーバーでも同じパスで公開するか、
-`vite.config.ts` の `base` オプションを変更して確認してください。
+`npm run build` で本番用ビルドを作成します。
+出力時のベースパスは `VITE_BASE_PATH` 環境変数で指定できます。
+GitHub Pages へデプロイする場合は `/RubicSolver/` を設定してください。
 
 このプロジェクトは [MIT License](LICENSE) の下で公開されています。
 

--- a/rubicsolver-app/README.md
+++ b/rubicsolver-app/README.md
@@ -15,6 +15,6 @@ npm run dev
 npm run build
 ```
 
-本番ビルドは `/RubicSolver/` を基点に生成されます。ローカル環境で確認する場合は
-同じパスでサーバーを立てるか、`vite.config.ts` の `base` を変更して調整してくださ
-い。
+ビルド時は `VITE_BASE_PATH` 環境変数でベースパスを指定できます。
+GitHub Pages で公開する場合は `/RubicSolver/` を設定してください。
+

--- a/rubicsolver-app/package-lock.json
+++ b/rubicsolver-app/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@types/node": "^24.0.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@types/three": "^0.177.0",
@@ -1543,6 +1544,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
@@ -8139,6 +8150,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/rubicsolver-app/package.json
+++ b/rubicsolver-app/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/three": "^0.177.0",
+    "@types/node": "^24.0.0",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/rubicsolver-app/vite.config.ts
+++ b/rubicsolver-app/vite.config.ts
@@ -1,8 +1,9 @@
+/// <reference types="node" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/RubicSolver/',
+  base: process.env.VITE_BASE_PATH ?? '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- use `VITE_BASE_PATH` environment variable in `vite.config.ts`
- document how to set `VITE_BASE_PATH` in READMEs
- add `@types/node` to dev dependencies to fix type errors

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68499939b7b08321a8aa950624c77987