### PR TITLE
Update project naming to RubikSolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# RubicSolver
+# RubikSolver
 
 Three.js と React を用いて 3×3×3 のルービックキューブを操作できる Web アプリです。  
-[デモはこちら](https://femon07.github.io/RubicSolver/) から利用できます。
+[デモはこちら](https://femon07.github.io/RubikSolver/) から利用できます。
 
 実装は `rubicsolver-app` ディレクトリにあります。次のコマンドで開発サーバーを起動できます。
 
@@ -11,7 +11,7 @@ npm ci
 npm run dev
 ```
 
-`npm run build` で本番用ビルドを作成します。ビルド後のファイルは `/RubicSolver/`
+`npm run build` で本番用ビルドを作成します。ビルド後のファイルは `/RubikSolver/`
 をベースとしたパスで出力されます。ローカルサーバーでも同じパスで公開するか、
 `vite.config.ts` の `base` オプションを変更して確認してください。
 

--- a/rubicsolver-app/README.md
+++ b/rubicsolver-app/README.md
@@ -1,4 +1,4 @@
-# RubicSolver アプリケーション
+# RubikSolver アプリケーション
 
 Vite と React で構築されたルービックキューブソルバーです。
 
@@ -15,6 +15,6 @@ npm run dev
 npm run build
 ```
 
-本番ビルドは `/RubicSolver/` を基点に生成されます。ローカル環境で確認する場合は
+本番ビルドは `/RubikSolver/` を基点に生成されます。ローカル環境で確認する場合は
 同じパスでサーバーを立てるか、`vite.config.ts` の `base` を変更して調整してくださ
 い。

--- a/rubicsolver-app/vite.config.ts
+++ b/rubicsolver-app/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/RubicSolver/',
+  base: '/RubikSolver/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- rename headings to **RubikSolver**
- update GitHub Pages links to `/RubikSolver/`
- set Vite base path to `/RubikSolver/`

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68499934baa08321823c706984ff3623