### PR TITLE
Fix base path for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
         working-directory: rubicsolver-app
       - run: npm run build
         working-directory: rubicsolver-app
+        env:
+          VITE_BASE_PATH: /RubicSolver/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: rubicsolver-app/dist


### PR DESCRIPTION
## Summary
- GitHub Pages の deploy ワークフローで `VITE_BASE_PATH` を `/RubicSolver/` に設定

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849a7af882c83219ef0bf47a3b7f86f