### PR TITLE
Add error handling with ErrorBoundary

### DIFF
--- a/rubicsolver-app/src/App.css
+++ b/rubicsolver-app/src/App.css
@@ -40,3 +40,8 @@
 .read-the-docs {
   color: #888;
 }
+
+.error {
+  color: red;
+  margin-bottom: 8px;
+}

--- a/rubicsolver-app/src/App.tsx
+++ b/rubicsolver-app/src/App.tsx
@@ -1,10 +1,13 @@
 import RubiksCube from './components/RubiksCube'
+import { useState } from 'react'
 import './App.css'
 
 function App() {
+  const [error, setError] = useState('')
   return (
     <div className="App">
-      <RubiksCube />
+      {error && <div className="error">{error}</div>}
+      <RubiksCube onError={setError} />
     </div>
   )
 }

--- a/rubicsolver-app/src/components/ErrorBoundary.tsx
+++ b/rubicsolver-app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import { Component, ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>予期せぬエラーが発生しました。ページを再読み込みしてください。</div>
+    }
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/rubicsolver-app/src/main.tsx
+++ b/rubicsolver-app/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## 変更内容
- 主要ハンドラで例外を捕捉し画面にメッセージを表示
- React Error Boundary を実装し `App` 全体をラップ
- エラーメッセージ表示用のスタイルを追加

## 動作確認
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a3290ee508321880b1479034203e8