### PR TITLE
Update CSS for bright theme

### DIFF
--- a/rubicsolver-app/src/index.css
+++ b/rubicsolver-app/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Comic Sans MS", "Kosugi Maru", system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #000;
+  background-color: #fff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -36,18 +36,21 @@ h1 {
 }
 
 button {
-  border-radius: 8px;
+  border-radius: 16px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #ffa500;
+  color: #000;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: border-color 0.25s, box-shadow 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #ff8c00;
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15);
 }
 button:focus,
 button:focus-visible {
@@ -56,13 +59,13 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: #000;
+    background-color: #fff;
   }
   a:hover {
-    color: #747bff;
+    color: #ff8c00;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #ffe0b3;
   }
 }


### PR DESCRIPTION
## Summary
- 背景色を白、文字色を黒に変更
- Comic Sans MS と Kosugi Maru を追加
- ボタンを明るいオレンジにし影を追加
- ライトモードの色設定を調整

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a35a93c748321a859b7a4f087864c