### PR TITLE
Fix random rotation pivot

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -113,8 +113,9 @@ function RubiksCube() {
 
       const selected = cubiesRef.current.filter((c) => Math.round(c.position[axis]) === layer)
       const rotationGroup = new THREE.Group()
-      selected.forEach((c) => rotationGroup.attach(c.mesh))
+      rotationGroup.position[axis] = layer
       groupRef.current!.add(rotationGroup)
+      selected.forEach((c) => rotationGroup.attach(c.mesh))
       const params: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 }
       params[axis] = angle
       gsap.to(rotationGroup.rotation, {


### PR DESCRIPTION
## 概要
ランダムボタンで回転した後にキューブが正方形でなくなる問題を修正しました。

## 変更点
- 回転グループの中心を各面のレイヤー位置に設定
- `npm ci` と `npm run lint` を実行して検証済み
- 既存テストも成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_684a3714c2a083219dc963dbfde62efd