### PR TITLE
Add scramble move count feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # RubicSolver
 この README の英語版は [README.en.md](README.en.md) を参照してください。
 
-Three.js と React を用いて 3×3×3 のルービックキューブを操作できる Web アプリです。  
+Three.js と React を用いて 3×3×3 のルービックキューブを操作できる Web アプリです。
 [デモはこちら](https://femon07.github.io/RubicSolver/) から利用できます。
+
+ランダムボタンの横に手数を入力する欄があり、指定した回数だけランダムにスクランブルできます。
 
 実装は `rubicsolver-app` ディレクトリにあります。次のコマンドで開発サーバーを起動できます。
 推奨 Node.js バージョンは **20 以上** です。

--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -38,12 +38,31 @@ function createCubieMaterials() {
   return materials
 }
 
+// 指定した手数のスクランブルを生成する
+function generateScramble(length: number) {
+  const faces = ['U', 'D', 'L', 'R', 'F', 'B']
+  const modifiers = ['', "'", '2']
+  const alg: string[] = []
+  let prev = ''
+  for (let i = 0; i < length; i++) {
+    let face = faces[Math.floor(Math.random() * faces.length)]
+    while (face === prev) {
+      face = faces[Math.floor(Math.random() * faces.length)]
+    }
+    prev = face
+    const mod = modifiers[Math.floor(Math.random() * modifiers.length)]
+    alg.push(face + mod)
+  }
+  return alg.join(' ')
+}
+
 function RubiksCube() {
   const groupRef = useRef<THREE.Group>(null)
   const cubiesRef = useRef<Cubie[]>([])
   const cubeRef = useRef(new Cube())
   const initialized = useRef(false)
   const [scramble, setScramble] = useState('')
+  const [scrambleLength, setScrambleLength] = useState(20)
 
   // コンポーネント初回マウント時にソルバーを初期化
   useEffect(() => {
@@ -137,7 +156,7 @@ function RubiksCube() {
 
   // ランダムにスクランブルする
   const handleRandom = async () => {
-    const alg = Cube.scramble()
+    const alg = generateScramble(scrambleLength)
     setScramble(alg)
     cubeRef.current = new Cube()
     await executeMoves(alg)
@@ -168,6 +187,16 @@ function RubiksCube() {
       </Canvas>
       <div style={{ marginTop: 10 }}>
         <button onClick={handleReset}>再描画</button>
+        <label style={{ marginLeft: 8 }}>
+          手数:
+          <input
+            type="number"
+            min={1}
+            value={scrambleLength}
+            onChange={(e) => setScrambleLength(Number(e.target.value))}
+            style={{ width: 60, marginLeft: 4 }}
+          />
+        </label>
         <button onClick={handleRandom} style={{ marginLeft: 8 }}>
           ランダム
         </button>


### PR DESCRIPTION
## Summary
- ランダムスクランブルの手数を指定できる関数を追加
- UI に手数入力欄を設置
- README に説明を追記

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a375345b08321aea61aae1c1e64e3