### PR TITLE
Fix ReactNode import for TS verbatimModuleSyntax

### DIFF
--- a/rubicsolver-app/src/ErrorBoundary.tsx
+++ b/rubicsolver-app/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactNode } from 'react'
+import { Component } from 'react'
+import type { ReactNode } from 'react'
 
 interface Props {
   children: ReactNode


### PR DESCRIPTION
## Summary
- GitHub Pages ビルドエラー修正のため、ErrorBoundary で ReactNode を型インポートに変更しました

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a439c0ec883219577adbeb03b153b