### PR TITLE
fix random scramble drift

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -148,6 +148,7 @@ function RubiksCube() {
               c.mesh.applyMatrix4(rotationGroup.matrix)
               const v = rotateVector(c.position, axis, angle)
               c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
+              c.mesh.position.set(c.position.x, c.position.y, c.position.z)
               groupRef.current!.attach(c.mesh)
             })
             groupRef.current!.remove(rotationGroup)


### PR DESCRIPTION
## Summary
- キューブ回転後に位置を丸めて保持するよう修正

## Testing
- `npm run lint`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_684a76f9b5e48321876f47e9f08709f5