### PR TITLE
Add GUI regression test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,12 @@
   git fetch origin
   git rebase origin/main
   ```
-- Prior to committing, install dependencies and run lint inside `rubicsolver-app`:
+- Prior to committing, install dependencies, run lint, and execute GUI regression tests inside `rubicsolver-app`:
   ```bash
   cd rubicsolver-app
   npm ci
   npm run lint
+  npm run test
   ```
 - Continuous integration checks run automatically when you open a PR. Ensure they pass.
 - The project typically merges PRs using **Create a merge commit**. Follow this strategy unless otherwise specified.

--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -64,6 +64,7 @@ function RubiksCube() {
   const [scramble, setScramble] = useState('')
   const [scrambleLength, setScrambleLength] = useState(20)
   const [errorMessage, setErrorMessage] = useState('')
+  const [cubeState, setCubeState] = useState(cubeRef.current.asString())
 
   // コンポーネント初回マウント時にソルバーを初期化
   useEffect(() => {
@@ -171,6 +172,7 @@ function RubiksCube() {
       cubeRef.current = new Cube()
       await executeMoves(alg)
       cubeRef.current.move(alg)
+      setCubeState(cubeRef.current.asString())
       setErrorMessage('')
     } catch (err) {
       console.error(err)
@@ -183,6 +185,7 @@ function RubiksCube() {
     cubeRef.current = new Cube()
     setScramble('')
     initCube()
+    setCubeState(cubeRef.current.asString())
   }
 
   // 現在の状態を解く
@@ -191,6 +194,7 @@ function RubiksCube() {
       const solution = cubeRef.current.solve()
       await executeMoves(solution)
       cubeRef.current.move(solution)
+      setCubeState(cubeRef.current.asString())
       setErrorMessage('')
     } catch (err) {
       console.error(err)
@@ -228,6 +232,9 @@ function RubiksCube() {
           そろえる
         </button>
         <div style={{ marginTop: 8 }}>スクランブル: {scramble}</div>
+        <div data-testid="cube-state" style={{ display: 'none' }}>
+          {cubeState}
+        </div>
         {errorMessage && (
           <div style={{ marginTop: 8, color: 'red' }}>{errorMessage}</div>
         )}

--- a/rubicsolver-app/src/types/cubejs.d.ts
+++ b/rubicsolver-app/src/types/cubejs.d.ts
@@ -5,6 +5,7 @@ declare module 'cubejs' {
     randomize(): void
     solve(maxDepth?: number): string
     isSolved(): boolean
+    asString(): string
     static random(): Cube
     static initSolver(): void
     static scramble(): string

--- a/rubicsolver-app/tests/cubeRegression.test.tsx
+++ b/rubicsolver-app/tests/cubeRegression.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import RubiksCube from '../src/components/RubiksCube'
+import Cube from 'cubejs'
+
+jest.mock('gsap', () => ({
+  to: (_target: unknown, { onComplete }: { onComplete?: () => void }) => {
+    if (onComplete) onComplete()
+    return {}
+  }
+}))
+
+test('1手回した後にそろえると元に戻る', async () => {
+  Cube.initSolver()
+  const solved = new Cube().asString()
+  render(<RubiksCube />)
+  const input = screen.getByLabelText('手数:') as HTMLInputElement
+  fireEvent.change(input, { target: { value: 1 } })
+  fireEvent.click(screen.getByText('ランダム'))
+  await waitFor(() => {
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+  })
+  fireEvent.click(screen.getByText('そろえる'))
+  await waitFor(() => {
+    expect(screen.getByTestId('cube-state').textContent).toBe(solved)
+  })
+})


### PR DESCRIPTION
## Summary
- GUIの状態を取得できるようにCubeの状態をDOMに出力
- Cubeの型定義を拡張
- GUIリグレッションテストを追加
- AGENTSにテスト実行ルールを追記

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684a79abe9e08321847ea24fb698b5f5