### PR TITLE
Fix random cube scramble

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -170,6 +170,7 @@ function RubiksCube() {
       const alg = generateScramble(scrambleLength)
       setScramble(alg)
       cubeRef.current = new Cube()
+      initCube()
       await executeMoves(alg)
       cubeRef.current.move(alg)
       setCubeState(cubeRef.current.asString())


### PR DESCRIPTION
## Summary
- adjust random scrambling to reset cube first

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a7dd880e48321b0e3450496b15479