### PR TITLE
CI 条件の更新

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   lint-test:
+    if: "!startsWith(github.head_ref, 'codex/')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,7 @@
   npm run lint
   npm run test
   ```
-- Continuous integration checks run automatically when you open a PR. Ensure they pass.
+- Continuous integration checks run automatically when you open a PR. However,
+  branches prefixed with `codex/` skip the lint and test workflow because these
+  checks run before the PR is created. Ensure other branches pass CI.
 - The project typically merges PRs using **Create a merge commit**. Follow this strategy unless otherwise specified.


### PR DESCRIPTION
## 概要
Codex が作成したブランチ `codex/` 系では、PR 作成前にテストを実行済みのため CI の `lint-test` ワークフローをスキップするようにしました。また AGENTS.md へこの運用を追記しました。

## テスト結果
- `npm run lint` 実行で警告のみ【4d3a4e†L1-L12】
- `npm test` 実行で全テスト成功【d27706†L1-L10】

------
https://chatgpt.com/codex/tasks/task_e_684a7efef0b4832195e4b55d82540fec