### PR TITLE
Modularize cube logic

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -2,180 +2,42 @@ import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useRef, useState, useEffect } from 'react'
 import * as THREE from 'three'
+import CubeController, { generateScramble } from '../lib/CubeController'
+import CubeRenderer from '../lib/CubeRenderer'
 import Cube from 'cubejs'
-import { gsap } from 'gsap'
-
-// 各キューブの小さいブロックを管理する型
-interface Cubie {
-  mesh: THREE.Mesh
-  position: THREE.Vector3
-}
-
-// 指定軸を中心にベクトルを回転させるユーティリティ
-function rotateVector(v: THREE.Vector3, axis: 'x' | 'y' | 'z', angle: number) {
-  const m = new THREE.Matrix4()
-  if (axis === 'x') m.makeRotationX(angle)
-  if (axis === 'y') m.makeRotationY(angle)
-  if (axis === 'z') m.makeRotationZ(angle)
-  return v.clone().applyMatrix4(m)
-}
-
-
-// 各面の色設定
-const faceColors = {
-  U: '#ffffff',
-  D: '#ffff00',
-  L: '#ff8000',
-  R: '#ff0000',
-  F: '#00ff00',
-  B: '#0000ff'
-}
-
-// 1つのキューブに貼るマテリアルを生成
-function createCubieMaterials() {
-  const colors = [faceColors.R, faceColors.L, faceColors.U, faceColors.D, faceColors.F, faceColors.B]
-  const materials = colors.map((color) => new THREE.MeshStandardMaterial({ color }))
-  return materials
-}
-
-// 指定した手数のスクランブルを生成する
-function generateScramble(length: number) {
-  const faces = ['U', 'D', 'L', 'R', 'F', 'B']
-  const modifiers = ['', "'", '2']
-  const alg: string[] = []
-  let prev = ''
-  for (let i = 0; i < length; i++) {
-    let face = faces[Math.floor(Math.random() * faces.length)]
-    while (face === prev) {
-      face = faces[Math.floor(Math.random() * faces.length)]
-    }
-    prev = face
-    const mod = modifiers[Math.floor(Math.random() * modifiers.length)]
-    alg.push(face + mod)
-  }
-  return alg.join(' ')
-}
 
 function RubiksCube() {
-  const groupRef = useRef<THREE.Group>(null)
-  const cubiesRef = useRef<Cubie[]>([])
-  const cubeRef = useRef(new Cube())
-  const initialized = useRef(false)
+  const rendererRef = useRef(new CubeRenderer())
+  const controllerRef = useRef(new CubeController())
   const [scramble, setScramble] = useState('')
   const [scrambleLength, setScrambleLength] = useState(20)
   const [errorMessage, setErrorMessage] = useState('')
-  const [cubeState, setCubeState] = useState(cubeRef.current.asString())
+  const [cubeState, setCubeState] = useState(controllerRef.current.getState())
 
-  // コンポーネント初回マウント時にソルバーを初期化
   useEffect(() => {
     Cube.initSolver()
   }, [])
 
-  // キューブを初期化する共通処理
-  const initCube = () => {
-    if (!groupRef.current) return
-    const g = groupRef.current
-    // 既存の子要素を削除
-    while (g.children.length) {
-      g.remove(g.children[0])
-    }
-    const cubies: Cubie[] = []
-    for (let x = -1; x <= 1; x++) {
-      for (let y = -1; y <= 1; y++) {
-        for (let z = -1; z <= 1; z++) {
-          const geometry = new THREE.BoxGeometry(0.98, 0.98, 0.98)
-          const materials = createCubieMaterials()
-          const mesh = new THREE.Mesh(geometry, materials)
-          mesh.position.set(x, y, z)
-          g.add(mesh)
-          cubies.push({ mesh, position: new THREE.Vector3(x, y, z) })
-        }
-      }
-    }
-    cubiesRef.current = cubies
-  }
-
-  // Canvas が準備できたタイミングで初期化を行う
   const setGroupRef = (node: THREE.Group | null) => {
-    groupRef.current = node
-    if (node && !initialized.current) {
-      initCube()
-      initialized.current = true
-    }
+    rendererRef.current.setGroup(node)
   }
 
-
-  // アルゴリズム文字列を順番に実行する
   const executeMoves = async (algorithm: string) => {
     const moves = algorithm.split(' ').filter(Boolean)
     for (const move of moves) {
-      await applyMove(move)
+      await rendererRef.current.applyMove(move)
     }
   }
 
-  // 1手の回転を実行してアニメーションする
-  const applyMove = (move: string) => {
-    return new Promise<void>((resolve) => {
-      try {
-        if (!groupRef.current) return resolve()
-        const face = move[0] as 'U' | 'D' | 'L' | 'R' | 'F' | 'B'
-        const modifier = move.length > 1 ? move[1] : ''
-        const axisMap: Record<string, { axis: 'x' | 'y' | 'z'; layer: number; dir: 1 | -1 }> = {
-          U: { axis: 'y', layer: 1, dir: 1 },
-          D: { axis: 'y', layer: -1, dir: -1 },
-          R: { axis: 'x', layer: 1, dir: 1 },
-          L: { axis: 'x', layer: -1, dir: -1 },
-          F: { axis: 'z', layer: 1, dir: 1 },
-          B: { axis: 'z', layer: -1, dir: -1 }
-        }
-        const { axis, layer, dir } = axisMap[face]
-        let angle = (Math.PI / 2) * dir
-        if (modifier === "'") angle *= -1
-        if (modifier === '2') angle *= 2
-
-        const selected = cubiesRef.current.filter((c) => Math.round(c.position[axis]) === layer)
-        const rotationGroup = new THREE.Group()
-        rotationGroup.position[axis] = layer
-        groupRef.current!.add(rotationGroup)
-        groupRef.current!.updateMatrixWorld(true)
-        rotationGroup.updateMatrixWorld(true)
-        selected.forEach((c) => rotationGroup.attach(c.mesh))
-        const params: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 }
-        params[axis] = angle
-        gsap.to(rotationGroup.rotation, {
-          ...params,
-          duration: 0.3,
-          onComplete: () => {
-            rotationGroup.updateMatrixWorld()
-            selected.forEach((c) => {
-              c.mesh.applyMatrix4(rotationGroup.matrix)
-              const v = rotateVector(c.position, axis, angle)
-              c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
-              c.mesh.position.set(c.position.x, c.position.y, c.position.z)
-              groupRef.current!.attach(c.mesh)
-            })
-            groupRef.current!.remove(rotationGroup)
-            resolve()
-          }
-        })
-      } catch (err) {
-        console.error(err)
-        setErrorMessage('操作中にエラーが発生しました')
-        resolve()
-      }
-    })
-  }
-
-  // ランダムにスクランブルする
   const handleRandom = async () => {
     try {
       const alg = generateScramble(scrambleLength)
       setScramble(alg)
-      cubeRef.current = new Cube()
-      initCube()
+      controllerRef.current.reset()
+      rendererRef.current.reset()
       await executeMoves(alg)
-      cubeRef.current.move(alg)
-      setCubeState(cubeRef.current.asString())
+      controllerRef.current.executeMoves(alg)
+      setCubeState(controllerRef.current.getState())
       setErrorMessage('')
     } catch (err) {
       console.error(err)
@@ -183,21 +45,19 @@ function RubiksCube() {
     }
   }
 
-  // キューブを再描画する
   const handleReset = () => {
-    cubeRef.current = new Cube()
+    controllerRef.current.reset()
     setScramble('')
-    initCube()
-    setCubeState(cubeRef.current.asString())
+    rendererRef.current.reset()
+    setCubeState(controllerRef.current.getState())
   }
 
-  // 現在の状態を解く
   const handleSolve = async () => {
     try {
-      const solution = cubeRef.current.solve()
+      const solution = controllerRef.current.solve()
       await executeMoves(solution)
-      cubeRef.current.move(solution)
-      setCubeState(cubeRef.current.asString())
+      controllerRef.current.executeMoves(solution)
+      setCubeState(controllerRef.current.getState())
       setErrorMessage('')
     } catch (err) {
       console.error(err)
@@ -207,10 +67,7 @@ function RubiksCube() {
 
   return (
     <div>
-      <Canvas
-        camera={{ position: [5, 5, 5], fov: 40 }}
-        style={{ height: 500, width: '100%' }}
-      >
+      <Canvas camera={{ position: [5, 5, 5], fov: 40 }} style={{ height: 500, width: '100%' }}>
         <ambientLight />
         <pointLight position={[10, 10, 10]} />
         <group ref={setGroupRef} />
@@ -238,9 +95,7 @@ function RubiksCube() {
         <div data-testid="cube-state" style={{ display: 'none' }}>
           {cubeState}
         </div>
-        {errorMessage && (
-          <div style={{ marginTop: 8, color: 'red' }}>{errorMessage}</div>
-        )}
+        {errorMessage && <div style={{ marginTop: 8, color: 'red' }}>{errorMessage}</div>}
       </div>
     </div>
   )

--- a/rubicsolver-app/src/lib/CubeController.ts
+++ b/rubicsolver-app/src/lib/CubeController.ts
@@ -1,0 +1,48 @@
+import Cube from 'cubejs'
+
+export default class CubeController {
+  cube: Cube
+
+  constructor() {
+    this.cube = new Cube()
+  }
+
+  reset() {
+    this.cube = new Cube()
+  }
+
+  applyMove(move: string) {
+    this.cube.move(move)
+  }
+
+  executeMoves(algorithm: string) {
+    this.cube.move(algorithm)
+  }
+
+  solve(): string {
+    return this.cube.solve()
+  }
+
+  getState(): string {
+    return this.cube.asString()
+  }
+
+  static generateScramble(length: number) {
+    const faces = ['U', 'D', 'L', 'R', 'F', 'B']
+    const modifiers = ['', "'", '2']
+    const alg: string[] = []
+    let prev = ''
+    for (let i = 0; i < length; i++) {
+      let face = faces[Math.floor(Math.random() * faces.length)]
+      while (face === prev) {
+        face = faces[Math.floor(Math.random() * faces.length)]
+      }
+      prev = face
+      const mod = modifiers[Math.floor(Math.random() * modifiers.length)]
+      alg.push(face + mod)
+    }
+    return alg.join(' ')
+  }
+}
+
+export const generateScramble = CubeController.generateScramble

--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -1,0 +1,113 @@
+import * as THREE from 'three'
+import { gsap } from 'gsap'
+
+interface Cubie {
+  mesh: THREE.Mesh
+  position: THREE.Vector3
+}
+
+export default class CubeRenderer {
+  group: THREE.Group | null = null
+  cubies: Cubie[] = []
+  initialized = false
+
+  setGroup(node: THREE.Group | null) {
+    this.group = node
+    if (node && !this.initialized) {
+      this.initCube()
+      this.initialized = true
+    }
+  }
+
+  private createCubieMaterials() {
+    const faceColors = {
+      U: '#ffffff',
+      D: '#ffff00',
+      L: '#ff8000',
+      R: '#ff0000',
+      F: '#00ff00',
+      B: '#0000ff'
+    }
+    const colors = [faceColors.R, faceColors.L, faceColors.U, faceColors.D, faceColors.F, faceColors.B]
+    return colors.map((color) => new THREE.MeshStandardMaterial({ color }))
+  }
+
+  private initCube() {
+    if (!this.group) return
+    while (this.group.children.length) {
+      this.group.remove(this.group.children[0])
+    }
+    const cubies: Cubie[] = []
+    for (let x = -1; x <= 1; x++) {
+      for (let y = -1; y <= 1; y++) {
+        for (let z = -1; z <= 1; z++) {
+          const geometry = new THREE.BoxGeometry(0.98, 0.98, 0.98)
+          const materials = this.createCubieMaterials()
+          const mesh = new THREE.Mesh(geometry, materials)
+          mesh.position.set(x, y, z)
+          this.group.add(mesh)
+          cubies.push({ mesh, position: new THREE.Vector3(x, y, z) })
+        }
+      }
+    }
+    this.cubies = cubies
+  }
+
+  private rotateVector(v: THREE.Vector3, axis: 'x' | 'y' | 'z', angle: number) {
+    const m = new THREE.Matrix4()
+    if (axis === 'x') m.makeRotationX(angle)
+    if (axis === 'y') m.makeRotationY(angle)
+    if (axis === 'z') m.makeRotationZ(angle)
+    return v.clone().applyMatrix4(m)
+  }
+
+  applyMove(move: string) {
+    return new Promise<void>((resolve) => {
+      if (!this.group) return resolve()
+      const face = move[0] as 'U' | 'D' | 'L' | 'R' | 'F' | 'B'
+      const modifier = move.length > 1 ? move[1] : ''
+      const axisMap: Record<string, { axis: 'x' | 'y' | 'z'; layer: number; dir: 1 | -1 }> = {
+        U: { axis: 'y', layer: 1, dir: 1 },
+        D: { axis: 'y', layer: -1, dir: -1 },
+        R: { axis: 'x', layer: 1, dir: 1 },
+        L: { axis: 'x', layer: -1, dir: -1 },
+        F: { axis: 'z', layer: 1, dir: 1 },
+        B: { axis: 'z', layer: -1, dir: -1 }
+      }
+      const { axis, layer, dir } = axisMap[face]
+      let angle = (Math.PI / 2) * dir
+      if (modifier === "'") angle *= -1
+      if (modifier === '2') angle *= 2
+
+      const selected = this.cubies.filter((c) => Math.round(c.position[axis]) === layer)
+      const rotationGroup = new THREE.Group()
+      rotationGroup.position[axis] = layer
+      this.group.add(rotationGroup)
+      this.group.updateMatrixWorld(true)
+      rotationGroup.updateMatrixWorld(true)
+      selected.forEach((c) => rotationGroup.attach(c.mesh))
+      const params: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 }
+      params[axis] = angle
+      gsap.to(rotationGroup.rotation, {
+        ...params,
+        duration: 0.3,
+        onComplete: () => {
+          rotationGroup.updateMatrixWorld()
+          selected.forEach((c) => {
+            c.mesh.applyMatrix4(rotationGroup.matrix)
+            const v = this.rotateVector(c.position, axis, angle)
+            c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
+            c.mesh.position.set(c.position.x, c.position.y, c.position.z)
+            this.group!.attach(c.mesh)
+          })
+          this.group!.remove(rotationGroup)
+          resolve()
+        }
+      })
+    })
+  }
+
+  reset() {
+    this.initCube()
+  }
+}

--- a/rubicsolver-app/tests/scrambleSolve.test.ts
+++ b/rubicsolver-app/tests/scrambleSolve.test.ts
@@ -1,4 +1,4 @@
-import { generateScramble } from '../src/components/RubiksCube';
+import { generateScramble } from '../src/lib/CubeController';
 import Cube from 'cubejs';
 
 // スクランブル生成のテスト


### PR DESCRIPTION
## Summary
- Cube関連の処理をCubeControllerクラスへ移動
- Three.js描画をCubeRendererクラスへ抽出
- RubiksCubeコンポーネントをリファクタして新クラスを利用
- スクランブル生成テストを更新

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a812f900083218d5e6d8b38f790e8