### PR TITLE
Add manual move regression tests

### DIFF
--- a/rubicsolver-app/tests/manualMoves.test.ts
+++ b/rubicsolver-app/tests/manualMoves.test.ts
@@ -1,0 +1,25 @@
+import CubeController from '../src/lib/CubeController'
+import Cube from 'cubejs'
+
+// 1手動かして正しい状態か確認
+it('U面を1回回した状態が正しい', () => {
+  Cube.initSolver()
+  const controller = new CubeController()
+  controller.applyMove('U')
+  const cube = new Cube()
+  cube.move('U')
+  const expected = cube.asString()
+  expect(controller.getState()).toBe(expected)
+})
+
+// 別の面をさらに1手動かして正しい状態か確認
+it('U面に続いてF面を1回回した状態が正しい', () => {
+  Cube.initSolver()
+  const controller = new CubeController()
+  controller.applyMove('U')
+  controller.applyMove('F')
+  const cube = new Cube()
+  cube.move('U F')
+  const expected = cube.asString()
+  expect(controller.getState()).toBe(expected)
+})


### PR DESCRIPTION
## Summary
- GUIリグレッションテストに手動操作のテストを追加

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a848cb4388321bc8a474bae355d40