### PR TITLE
Add faint fractal background

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 この README の英語版は [README.en.md](README.en.md) を参照してください。
 
 Three.js と React を用いて 3×3×3 のルービックキューブを操作できる Web アプリです。
+背景には `public/fractal.svg` を利用した淡いフラクタル模様を使用しています。
 [デモはこちら](https://femon07.github.io/RubicSolver/) から利用できます。
 
 ランダムボタンの横に手数を入力する欄があり、指定した回数だけランダムにスクランブルできます。

--- a/rubicsolver-app/public/fractal.svg
+++ b/rubicsolver-app/public/fractal.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <filter id="noise">
+    <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" seed="2"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noise)" opacity="0.12" />
+</svg>

--- a/rubicsolver-app/src/index.css
+++ b/rubicsolver-app/src/index.css
@@ -28,6 +28,9 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-image: url('fractal.svg');
+  background-size: cover;
+  background-attachment: fixed;
 }
 
 h1 {


### PR DESCRIPTION
## 概要
- フラクタル模様の SVG を追加
- アプリ全体の背景として `fractal.svg` を適用
- README に背景変更の説明を追記

## テスト結果
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a85501eb48321bba89bed3f88153b