### PR TITLE
Fix scramble axis repetition

### DIFF
--- a/rubicsolver-app/src/lib/CubeController.ts
+++ b/rubicsolver-app/src/lib/CubeController.ts
@@ -30,14 +30,26 @@ export default class CubeController {
   static generateScramble(length: number) {
     const faces = ['U', 'D', 'L', 'R', 'F', 'B']
     const modifiers = ['', "'", '2']
+    const axisMap: Record<string, string> = {
+      U: 'UD',
+      D: 'UD',
+      L: 'LR',
+      R: 'LR',
+      F: 'FB',
+      B: 'FB'
+    }
     const alg: string[] = []
-    let prev = ''
+    let prevAxis = ''
+    let prevFace = ''
     for (let i = 0; i < length; i++) {
       let face = faces[Math.floor(Math.random() * faces.length)]
-      while (face === prev) {
+      let axis = axisMap[face]
+      while (face === prevFace || axis === prevAxis) {
         face = faces[Math.floor(Math.random() * faces.length)]
+        axis = axisMap[face]
       }
-      prev = face
+      prevFace = face
+      prevAxis = axis
       const mod = modifiers[Math.floor(Math.random() * modifiers.length)]
       alg.push(face + mod)
     }

--- a/rubicsolver-app/tests/scrambleSolve.test.ts
+++ b/rubicsolver-app/tests/scrambleSolve.test.ts
@@ -11,6 +11,28 @@ it('generateScramble が指定手数のスクランブルを生成する', () =>
   }
 });
 
+// 同じ軸が連続しないか確認
+it('generateScramble で連続して同じ軸を選ばない', () => {
+  const axisMap: Record<string, string> = {
+    U: 'UD',
+    D: 'UD',
+    L: 'LR',
+    R: 'LR',
+    F: 'FB',
+    B: 'FB'
+  };
+  const alg = generateScramble(20);
+  const moves = alg.split(' ').filter(Boolean);
+  let prevAxis = '';
+  for (const move of moves) {
+    const axis = axisMap[move[0]];
+    if (prevAxis) {
+      expect(axis).not.toBe(prevAxis);
+    }
+    prevAxis = axis;
+  }
+});
+
 // スクランブル後に solve を実行して元に戻るかを確認
 it('Cube.solve でスクランブル状態から復元できる', () => {
   Cube.initSolver();


### PR DESCRIPTION
## 概要
`generateScramble` が同じ軸を続けて選ぶ場合がありました。新しいリグレッションテストではこの点を検証するため、テスト失敗となっていました。

## 変更点
- `CubeController.generateScramble` を改良し、直前と同じ軸を避けるようにしました。
- 上記を確認するテスト `generateScramble で連続して同じ軸を選ばない` を追加しました。

## テスト結果
- `npm run lint` と `npm test` を実行し、いずれも成功することを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_684a8623a9f48321bebdcd31cf161ddf