### PR TITLE
Fix cube duplication when randomizing

### DIFF
--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -115,15 +115,14 @@ export default class CubeRenderer {
 
   dispose() {
     if (!this.group) return
-    this.group.traverse((child) => {
-      if ((child as THREE.Mesh).isMesh) {
-        const mesh = child as THREE.Mesh
+    this.group.traverse((obj) => {
+      if ((obj as THREE.Mesh).isMesh) {
+        const mesh = obj as THREE.Mesh
         mesh.geometry.dispose()
-        if (Array.isArray(mesh.material)) {
-          mesh.material.forEach((m) => m.dispose())
-        } else {
-          ;(mesh.material as THREE.Material).dispose()
-        }
+        const mats = Array.isArray(mesh.material)
+          ? mesh.material
+          : [mesh.material]
+        mats.forEach((m) => m.dispose())
       }
     })
     while (this.group.children.length) {


### PR DESCRIPTION
## Summary
- ランダム実行時にグループをシーンから除去して新規生成
- dispose() を更新し、メッシュの破棄を厳密化

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684a8c3117ec8321bfb90a600f316f06