### PR TITLE
Add rotation buttons and API

### DIFF
--- a/rubicsolver-app/src/types/cubemodel.d.ts
+++ b/rubicsolver-app/src/types/cubemodel.d.ts
@@ -1,0 +1,9 @@
+export {}
+
+declare global {
+  interface Window {
+    cubeModel: {
+      applyMoves: (moves: string[]) => Promise<void>
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ルービックキューブ各面の左右回転ボタンを追加
- キー入力ショートカットとヘルプ表示を実装
- `window.cubeModel.applyMoves()` を公開し、外部から回転操作可能に
- ボタン/ショートカット/API での操作が常に同期されるよう更新

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684aea7f58748321b33d38fc80d407ab