### PR TITLE
Implement renderer state tracking

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube.tsx
+++ b/rubicsolver-app/src/components/RubiksCube.tsx
@@ -1,6 +1,13 @@
 import { Canvas, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
-import { useRef, useState, useEffect, useCallback } from 'react'
+import {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  forwardRef,
+  useImperativeHandle
+} from 'react'
 import * as THREE from 'three'
 import CubeController, { generateScramble } from '../lib/CubeController'
 import CubeRenderer from '../lib/CubeRenderer'
@@ -14,7 +21,13 @@ function SceneGrabber({ sceneRef }: { sceneRef: React.MutableRefObject<THREE.Sce
   return null
 }
 
-function RubiksCube() {
+function RubiksCube(
+  _props: unknown,
+  ref: React.Ref<{
+    getRendererState: () => string
+    getControllerState: () => string
+  }>
+) {
   const rendererRef = useRef(new CubeRenderer())
   const controllerRef = useRef(new CubeController())
   const sceneRef = useRef<THREE.Scene | null>(null)
@@ -27,6 +40,12 @@ function RubiksCube() {
   useEffect(() => {
     Cube.initSolver()
   }, [])
+
+  useImperativeHandle(ref, () => ({
+    getRendererState: () => rendererRef.current.getState(),
+    getControllerState: () => controllerRef.current.getState(),
+    initRenderer: () => rendererRef.current.setGroup(new THREE.Group())
+  }))
 
 
 
@@ -219,5 +238,5 @@ B: B面を右回転 / Shift+B: B面を左回転
   )
 }
 
-export default RubiksCube
+export default forwardRef(RubiksCube)
 export { generateScramble }

--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -1,16 +1,28 @@
 import * as THREE from 'three'
 import { gsap } from 'gsap'
+import Cube from 'cubejs'
 import { COLORS } from '../constants/colors'
+
+interface Orientation {
+  'x+': string | null
+  'x-': string | null
+  'y+': string | null
+  'y-': string | null
+  'z+': string | null
+  'z-': string | null
+}
 
 interface Cubie {
   mesh: THREE.Mesh
   position: THREE.Vector3
+  orientation: Orientation
 }
 
 export default class CubeRenderer {
   group: THREE.Group | null = null
   cubies: Cubie[] = []
   initialized = false
+  cubeModel = new Cube()
 
   setGroup(node: THREE.Group | null) {
     this.group = node
@@ -34,11 +46,21 @@ export default class CubeRenderer {
   }
 
   private initCube() {
-    if (!this.group) return
-    while (this.group.children.length) {
-      this.group.remove(this.group.children[0])
+    if (this.group) {
+      while (this.group.children.length) {
+        this.group.remove(this.group.children[0])
+      }
     }
+    this.cubeModel = new Cube()
     const cubies: Cubie[] = []
+    const baseOrientation: Orientation = {
+      'x+': 'R',
+      'x-': 'L',
+      'y+': 'U',
+      'y-': 'D',
+      'z+': 'F',
+      'z-': 'B'
+    }
     for (let x = -1; x <= 1; x++) {
       for (let y = -1; y <= 1; y++) {
         for (let z = -1; z <= 1; z++) {
@@ -46,8 +68,18 @@ export default class CubeRenderer {
           const materials = this.createCubieMaterials()
           const mesh = new THREE.Mesh(geometry, materials)
           mesh.position.set(x, y, z)
-          this.group.add(mesh)
-          cubies.push({ mesh, position: new THREE.Vector3(x, y, z) })
+          if (this.group) {
+            this.group.add(mesh)
+          }
+          const orientation: Orientation = {
+            'x+': x === 1 ? baseOrientation['x+'] : null,
+            'x-': x === -1 ? baseOrientation['x-'] : null,
+            'y+': y === 1 ? baseOrientation['y+'] : null,
+            'y-': y === -1 ? baseOrientation['y-'] : null,
+            'z+': z === 1 ? baseOrientation['z+'] : null,
+            'z-': z === -1 ? baseOrientation['z-'] : null
+          }
+          cubies.push({ mesh, position: new THREE.Vector3(x, y, z), orientation })
         }
       }
     }
@@ -62,9 +94,40 @@ export default class CubeRenderer {
     return v.clone().applyMatrix4(m)
   }
 
+  private rotateOrientation(cubie: Cubie, axis: 'x' | 'y' | 'z', angle: number) {
+    const dirs: Record<string, THREE.Vector3> = {
+      'x+': new THREE.Vector3(1, 0, 0),
+      'x-': new THREE.Vector3(-1, 0, 0),
+      'y+': new THREE.Vector3(0, 1, 0),
+      'y-': new THREE.Vector3(0, -1, 0),
+      'z+': new THREE.Vector3(0, 0, 1),
+      'z-': new THREE.Vector3(0, 0, -1)
+    }
+    const newOri: Orientation = {
+      'x+': null,
+      'x-': null,
+      'y+': null,
+      'y-': null,
+      'z+': null,
+      'z-': null
+    }
+    ;(Object.keys(dirs) as Array<keyof Orientation>).forEach((k) => {
+      const vec = this.rotateVector(dirs[k], axis, angle)
+      const key = (() => {
+        if (Math.round(vec.x) === 1) return 'x+'
+        if (Math.round(vec.x) === -1) return 'x-'
+        if (Math.round(vec.y) === 1) return 'y+'
+        if (Math.round(vec.y) === -1) return 'y-'
+        if (Math.round(vec.z) === 1) return 'z+'
+        return 'z-' as const
+      })()
+      newOri[key] = cubie.orientation[k]
+    })
+    cubie.orientation = newOri
+  }
+
   applyMove(move: string) {
     return new Promise<void>((resolve) => {
-      if (!this.group) return resolve()
       const face = move[0] as 'U' | 'D' | 'L' | 'R' | 'F' | 'B'
       const modifier = move.length > 1 ? move[1] : ''
       const axisMap: Record<string, { axis: 'x' | 'y' | 'z'; layer: number; dir: 1 | -1 }> = {
@@ -81,32 +144,48 @@ export default class CubeRenderer {
       if (modifier === '2') angle *= 2
 
       const selected = this.cubies.filter((c) => Math.round(c.position[axis]) === layer)
-      const rotationGroup = new THREE.Group()
-      rotationGroup.position[axis] = layer
-      this.group.add(rotationGroup)
-      this.group.updateMatrixWorld(true)
-      rotationGroup.updateMatrixWorld(true)
-      selected.forEach((c) => rotationGroup.attach(c.mesh))
-      const params: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 }
-      params[axis] = angle
-      gsap.to(rotationGroup.rotation, {
-        ...params,
-        duration: 0.3,
-        onComplete: () => {
-          rotationGroup.updateMatrixWorld()
-          selected.forEach((c) => {
-            c.mesh.applyMatrix4(rotationGroup.matrix)
-            const v = this.rotateVector(c.position, axis, angle)
-            c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
-            c.mesh.position.set(c.position.x, c.position.y, c.position.z)
-            this.group!.attach(c.mesh)
-          })
-          this.group!.remove(rotationGroup)
-          rotationGroup.clear()
-          resolve()
-        }
-      })
+      if (this.group) {
+        const rotationGroup = new THREE.Group()
+        rotationGroup.position[axis] = layer
+        this.group.add(rotationGroup)
+        this.group.updateMatrixWorld(true)
+        rotationGroup.updateMatrixWorld(true)
+        selected.forEach((c) => rotationGroup.attach(c.mesh))
+        const params: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 }
+        params[axis] = angle
+        gsap.to(rotationGroup.rotation, {
+          ...params,
+          duration: 0.3,
+          onComplete: () => {
+            rotationGroup.updateMatrixWorld()
+            selected.forEach((c) => {
+              c.mesh.applyMatrix4(rotationGroup.matrix)
+              const v = this.rotateVector(c.position, axis, angle)
+              c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
+              c.mesh.position.set(c.position.x, c.position.y, c.position.z)
+              this.rotateOrientation(c, axis, angle)
+              this.group!.attach(c.mesh)
+            })
+            this.cubeModel.move(move)
+            this.group!.remove(rotationGroup)
+            rotationGroup.clear()
+            resolve()
+          }
+        })
+      } else {
+        selected.forEach((c) => {
+          const v = this.rotateVector(c.position, axis, angle)
+          c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
+          this.rotateOrientation(c, axis, angle)
+        })
+        this.cubeModel.move(move)
+        resolve()
+      }
     })
+  }
+
+  getState(): string {
+    return this.cubeModel.asString()
   }
 
   reset() {

--- a/rubicsolver-app/tests/cubeRegression.test.tsx
+++ b/rubicsolver-app/tests/cubeRegression.test.tsx
@@ -4,6 +4,12 @@ import RubiksCube from '../src/components/RubiksCube'
 import Cube from 'cubejs'
 
 jest.mock('gsap', () => ({
+  gsap: {
+    to: (_target: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  },
   to: (_target: unknown, { onComplete }: { onComplete?: () => void }) => {
     if (onComplete) onComplete()
     return {}

--- a/rubicsolver-app/tests/rendererConsistency.test.tsx
+++ b/rubicsolver-app/tests/rendererConsistency.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React from 'react'
+import RubiksCube from '../src/components/RubiksCube'
+import Cube from 'cubejs'
+
+jest.mock('gsap', () => ({
+  gsap: {
+    to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  },
+  to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+    if (onComplete) onComplete()
+    return {}
+  }
+}))
+
+test('回転後にビューとモデルの状態が一致する', async () => {
+  Cube.initSolver()
+  const ref = React.createRef<{
+    getRendererState: () => string
+    getControllerState: () => string
+    initRenderer: () => void
+  }>()
+  render(<RubiksCube ref={ref} />)
+  ref.current?.initRenderer()
+  fireEvent.click(screen.getByText('U →'))
+  await waitFor(() => {
+    expect(ref.current?.getRendererState()).toBe(
+      ref.current?.getControllerState()
+    )
+  })
+  fireEvent.click(screen.getByText('F →'))
+  await waitFor(() => {
+    expect(ref.current?.getRendererState()).toBe(
+      ref.current?.getControllerState()
+    )
+  })
+})
+


### PR DESCRIPTION
## Summary
- CubeRendererに面の向きを保持する`orientation`を追加
- CubeRenderer内で`cubejs`を用いた状態管理を実装し`getState()`を公開
- RubiksCubeからrenderer/controllerの状態を取得できるようにし、初期化メソッドを追加
- rendererとcontrollerの状態一致を確認するテストを追加
- gsapのモックを更新

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684af0dad4bc8321b3a11da630be0cf4