### PR TITLE
READMEにショートカット追加

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,17 @@ npm run dev
 
 Use `npm run build` to create a production build. The base path can be specified with the `VITE_BASE_PATH` environment variable. Set it to `/RubicSolver/` when deploying to GitHub Pages.
 
+## Keyboard Shortcuts
+
+```
+U: rotate the U face clockwise / Shift+U: rotate the U face counterclockwise
+R: rotate the R face clockwise / Shift+R: rotate the R face counterclockwise
+F: rotate the F face clockwise / Shift+F: rotate the F face counterclockwise
+D: rotate the D face clockwise / Shift+D: rotate the D face counterclockwise
+L: rotate the L face clockwise / Shift+L: rotate the L face counterclockwise
+B: rotate the B face clockwise / Shift+B: rotate the B face counterclockwise
+```
+
 Install dependencies before running lint or build tasks. Execute the following command to run lint.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ npm run dev
 出力時のベースパスは `VITE_BASE_PATH` 環境変数で指定できます。
 GitHub Pages へデプロイする場合は `/RubicSolver/` を設定してください。
 
+## キーボードショートカット
+
+```
+U: U面を右回転 / Shift+U: U面を左回転
+R: R面を右回転 / Shift+R: R面を左回転
+F: F面を右回転 / Shift+F: F面を左回転
+D: D面を右回転 / Shift+D: D面を左回転
+L: L面を右回転 / Shift+L: L面を左回転
+B: B面を右回転 / Shift+B: B面を左回転
+```
+
 Lint やビルドを実行する前には依存関係をインストールしておく必要があります。次の
 コマンドで Lint を実行できます。
 


### PR DESCRIPTION
## 変更内容
- RubiksCube.tsx に合わせて各 README にキーボードショートカット表を追加

## 動作確認
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684af825f9348321aedd6067223c747e