### PR TITLE
Add Cube model and renderer tests

### DIFF
--- a/__tests__/CubeModel.test.ts
+++ b/__tests__/CubeModel.test.ts
@@ -1,0 +1,45 @@
+import CubeModel from '../rubicsolver-app/src/model/CubeModel'
+import { COLORS } from '../rubicsolver-app/src/constants/colors'
+
+const map = {
+  U: COLORS.U,
+  R: COLORS.R,
+  F: COLORS.F,
+  D: COLORS.D,
+  L: COLORS.L,
+  B: COLORS.B
+}
+
+const expectedState = (alg: string) => {
+  const Cube = require('../rubicsolver-app/node_modules/cubejs')
+  Cube.initSolver()
+  const cube = new Cube()
+  cube.move(alg)
+  return cube.asString().split('').map((c: string) => map[c as keyof typeof map])
+}
+
+test("初期状態で U' を適用すると正しい面配置になる", () => {
+  const model = new CubeModel()
+  model.applyMoves("U'")
+  expect(model.getFacelets()).toEqual(expectedState("U'"))
+})
+
+test('R を適用すると正しい状態になる', () => {
+  const model = new CubeModel()
+  model.applyMoves('R')
+  expect(model.getFacelets()).toEqual(expectedState('R'))
+})
+
+test('L を適用すると正しい状態になる', () => {
+  const model = new CubeModel()
+  model.applyMoves('L')
+  expect(model.getFacelets()).toEqual(expectedState('L'))
+})
+
+test('F を適用すると正しい状態になる', () => {
+  const model = new CubeModel()
+  model.applyMoves('F')
+  expect(model.getFacelets()).toEqual(expectedState('F'))
+})
+
+

--- a/__tests__/CubeRenderer.test.ts
+++ b/__tests__/CubeRenderer.test.ts
@@ -1,0 +1,44 @@
+import CubeRenderer from '../rubicsolver-app/src/lib/CubeRenderer'
+// @ts-ignore
+import * as THREE from '../rubicsolver-app/node_modules/three/build/three.cjs'
+import { COLORS } from '../rubicsolver-app/src/constants/colors'
+
+jest.mock('../rubicsolver-app/node_modules/gsap', () => ({
+  gsap: {
+    to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  }
+}))
+
+test('初期化時のキュービー配置と色が正しい', () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  for (const cubie of renderer.cubies) {
+    const mesh = cubie.mesh
+    expect(mesh.position.x).toBe(cubie.position.x)
+    expect(mesh.position.y).toBe(cubie.position.y)
+    expect(mesh.position.z).toBe(cubie.position.z)
+    const mats = mesh.material as any
+    expect(mats[0].color.getHex()).toBe(COLORS.R)
+    expect(mats[1].color.getHex()).toBe(COLORS.L)
+    expect(mats[2].color.getHex()).toBe(COLORS.U)
+  }
+})
+
+test('モデルとレンダラーの状態が一致する', async () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  await renderer.applyMove('U')
+  const state = renderer.getState()
+  const Cube = require('../rubicsolver-app/node_modules/cubejs')
+  Cube.initSolver()
+  const cube = new Cube()
+  cube.move('U')
+  expect(state).toBe(cube.asString())
+})
+
+

--- a/rubicsolver-app/jest.config.js
+++ b/rubicsolver-app/jest.config.js
@@ -11,6 +11,7 @@ export default {
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',
   },
+  roots: ['<rootDir>', '../__tests__'],
   setupFiles: ['<rootDir>/tests/setup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/rubicsolver-app/src/model/CubeModel.ts
+++ b/rubicsolver-app/src/model/CubeModel.ts
@@ -1,0 +1,27 @@
+import Cube from 'cubejs'
+import { COLORS } from '../constants/colors'
+
+export default class CubeModel {
+  private cube: Cube
+
+  constructor() {
+    this.cube = new Cube()
+  }
+
+  applyMoves(alg: string) {
+    this.cube.move(alg)
+  }
+
+  getFacelets(): number[] {
+    const str = this.cube.asString()
+    const map: Record<string, number> = {
+      U: COLORS.U,
+      D: COLORS.D,
+      L: COLORS.L,
+      R: COLORS.R,
+      F: COLORS.F,
+      B: COLORS.B
+    }
+    return str.split('').map((c) => map[c])
+  }
+}

--- a/rubicsolver-app/tsconfig.test.json
+++ b/rubicsolver-app/tsconfig.test.json
@@ -7,5 +7,5 @@
     "esModuleInterop": true,
     "allowJs": true
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "../__tests__"]
 }


### PR DESCRIPTION
## Summary
- add `CubeModel` class with facelet handling
- test cube rotations and facelet arrays
- verify renderer cubie setup and state sync
- adjust Jest/TS configs for new root tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684afd1d35b08321a1196d480056ca43