### PR TITLE
Add orientation tests and fix rotation

### DIFF
--- a/__tests__/CubeRenderer.test.ts
+++ b/__tests__/CubeRenderer.test.ts
@@ -42,3 +42,67 @@ test('モデルとレンダラーの状態が一致する', async () => {
 })
 
 
+
+test('R を適用すると cubie の座標と向きが正しい', async () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  const target = renderer.cubies.find(
+    (c) => c.position.x === 1 && c.position.y === 1 && c.position.z === 1
+  )!
+  await renderer.applyMove('R')
+  // デバッグ用に向きを出力する
+  expect(target.position.x).toBe(1)
+  expect(target.position.y).toBe(1)
+  expect(target.position.z).toBe(-1)
+  expect(target.orientation).toEqual({
+    'x+': 'R',
+    'x-': null,
+    'y+': 'F',
+    'y-': null,
+    'z+': null,
+    'z-': 'U'
+  })
+})
+
+test('R2 を適用すると cubie の座標と向きが正しい', async () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  const target = renderer.cubies.find(
+    (c) => c.position.x === 1 && c.position.y === 1 && c.position.z === 1
+  )!
+  await renderer.applyMove('R2')
+  expect(target.position.x).toBe(1)
+  expect(target.position.y).toBe(-1)
+  expect(target.position.z).toBe(-1)
+  expect(target.orientation).toEqual({
+    'x+': 'R',
+    'x-': null,
+    'y+': null,
+    'y-': 'U',
+    'z+': null,
+    'z-': 'F'
+  })
+})
+
+test('F を適用すると cubie の座標と向きが正しい', async () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  const target = renderer.cubies.find(
+    (c) => c.position.x === 1 && c.position.y === 1 && c.position.z === 1
+  )!
+  await renderer.applyMove('F')
+  expect(target.position.x).toBe(1)
+  expect(target.position.y).toBe(-1)
+  expect(target.position.z).toBe(1)
+  expect(target.orientation).toEqual({
+    'x+': 'U',
+    'x-': null,
+    'y+': null,
+    'y-': 'R',
+    'z+': 'F',
+    'z-': null
+  })
+})

--- a/__tests__/CubeRenderer.test.ts
+++ b/__tests__/CubeRenderer.test.ts
@@ -51,7 +51,6 @@ test('R を適用すると cubie の座標と向きが正しい', async () => {
     (c) => c.position.x === 1 && c.position.y === 1 && c.position.z === 1
   )!
   await renderer.applyMove('R')
-  // デバッグ用に向きを出力する
   expect(target.position.x).toBe(1)
   expect(target.position.y).toBe(1)
   expect(target.position.z).toBe(-1)

--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -86,12 +86,31 @@ export default class CubeRenderer {
     this.cubies = cubies
   }
 
-  private rotateVector(v: THREE.Vector3, axis: 'x' | 'y' | 'z', angle: number) {
+  private rotateVector(
+    v: THREE.Vector3,
+    axis: 'x' | 'y' | 'z',
+    angle: number,
+    offset = 0
+  ) {
     const m = new THREE.Matrix4()
-    if (axis === 'x') m.makeRotationX(angle)
-    if (axis === 'y') m.makeRotationY(angle)
-    if (axis === 'z') m.makeRotationZ(angle)
-    return v.clone().applyMatrix4(m)
+    const t = new THREE.Matrix4()
+    const tInv = new THREE.Matrix4()
+    if (axis === 'x') {
+      m.makeRotationX(angle)
+      t.makeTranslation(-offset, 0, 0)
+      tInv.makeTranslation(offset, 0, 0)
+    }
+    if (axis === 'y') {
+      m.makeRotationY(angle)
+      t.makeTranslation(0, -offset, 0)
+      tInv.makeTranslation(0, offset, 0)
+    }
+    if (axis === 'z') {
+      m.makeRotationZ(angle)
+      t.makeTranslation(0, 0, -offset)
+      tInv.makeTranslation(0, 0, offset)
+    }
+    return v.clone().applyMatrix4(t).applyMatrix4(m).applyMatrix4(tInv)
   }
 
   private rotateOrientation(cubie: Cubie, axis: 'x' | 'y' | 'z', angle: number) {
@@ -160,7 +179,7 @@ export default class CubeRenderer {
             rotationGroup.updateMatrixWorld()
             selected.forEach((c) => {
               c.mesh.applyMatrix4(rotationGroup.matrix)
-              const v = this.rotateVector(c.position, axis, angle)
+              const v = this.rotateVector(c.position, axis, angle, layer)
               c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
               c.mesh.position.set(c.position.x, c.position.y, c.position.z)
               this.rotateOrientation(c, axis, angle)
@@ -174,7 +193,7 @@ export default class CubeRenderer {
         })
       } else {
         selected.forEach((c) => {
-          const v = this.rotateVector(c.position, axis, angle)
+          const v = this.rotateVector(c.position, axis, angle, layer)
           c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
           this.rotateOrientation(c, axis, angle)
         })


### PR DESCRIPTION
## Summary
- verify cubie orientation and position after moves
- adjust rotation calculation to support axis offsets

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684b82baf9708321be72307208b742e3