### PR TITLE
Fix cubie color sync after rotations

### DIFF
--- a/__tests__/CubeRenderer.test.ts
+++ b/__tests__/CubeRenderer.test.ts
@@ -105,3 +105,38 @@ test('F を適用すると cubie の座標と向きが正しい', async () => {
     'z-': null
   })
 })
+
+test('回転後にキュービーの色が向きと一致する', async () => {
+  const renderer = new CubeRenderer()
+  const group = new THREE.Group()
+  renderer.setGroup(group)
+  const target = renderer.cubies.find(
+    (c) => c.position.x === 1 && c.position.y === 1 && c.position.z === 1
+  )!
+  await renderer.applyMove('R')
+  const mats = target.mesh.material as any
+  const map: Record<string, number> = {
+    U: COLORS.U,
+    D: COLORS.D,
+    L: COLORS.L,
+    R: COLORS.R,
+    F: COLORS.F,
+    B: COLORS.B
+  }
+  const order: Array<keyof typeof target.orientation> = [
+    'x+',
+    'x-',
+    'y+',
+    'y-',
+    'z+',
+    'z-'
+  ]
+  order.forEach((dir, idx) => {
+    const face = target.orientation[dir]
+    if (face) {
+      expect(mats[idx].color.getHex()).toBe(map[face])
+    } else {
+      expect(mats[idx].color.getHex()).toBe(0x000000)
+    }
+  })
+})

--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -18,6 +18,15 @@ interface Cubie {
   orientation: Orientation
 }
 
+const ORI_TO_COLOR: Record<string, number> = {
+  U: COLORS.U,
+  D: COLORS.D,
+  L: COLORS.L,
+  R: COLORS.R,
+  F: COLORS.F,
+  B: COLORS.B
+}
+
 export default class CubeRenderer {
   group: THREE.Group | null = null
   cubies: Cubie[] = []
@@ -86,6 +95,18 @@ export default class CubeRenderer {
     this.cubies = cubies
   }
 
+  private updateCubieColors(cubie: Cubie) {
+    const materials = cubie.mesh.material as THREE.MeshStandardMaterial[]
+    const order: Array<keyof Orientation> = ['x+', 'x-', 'y+', 'y-', 'z+', 'z-']
+    order.forEach((dir, idx) => {
+      const face = cubie.orientation[dir]
+      if (face) {
+        materials[idx].color.set(ORI_TO_COLOR[face])
+      } else {
+        materials[idx].color.set(0x000000)
+      }
+    })
+  }
   private rotateVector(
     v: THREE.Vector3,
     axis: 'x' | 'y' | 'z',
@@ -183,6 +204,7 @@ export default class CubeRenderer {
               c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
               c.mesh.position.set(c.position.x, c.position.y, c.position.z)
               this.rotateOrientation(c, axis, angle)
+              this.updateCubieColors(c)
               this.group!.attach(c.mesh)
             })
             this.cubeModel.move(move)
@@ -196,6 +218,7 @@ export default class CubeRenderer {
           const v = this.rotateVector(c.position, axis, angle, layer)
           c.position.set(Math.round(v.x), Math.round(v.y), Math.round(v.z))
           this.rotateOrientation(c, axis, angle)
+          this.updateCubieColors(c)
         })
         this.cubeModel.move(move)
         resolve()


### PR DESCRIPTION
## Summary
- 色情報の管理を `CubeRenderer` 内で更新するよう修正
- 回転後に各キュービーの色を向きに合わせて再設定
- 上記を確認するテストを追加

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684b8fceab808321a4de8f7552225cbf