### PR TITLE
CIビルド追加

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,4 @@
-name: Lint and Test
+name: Lint, Test and Build
 
 on:
   pull_request:
@@ -19,4 +19,6 @@ jobs:
       - run: npm run lint
         working-directory: rubicsolver-app
       - run: npm test
+        working-directory: rubicsolver-app
+      - run: npm run build
         working-directory: rubicsolver-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
   npm ci
   npm run lint
   npm run test
+  npm run build
   ```
 - Continuous integration checks run automatically when you open a PR. However,
   branches prefixed with `codex/` skip the lint and test workflow because these

--- a/README.en.md
+++ b/README.en.md
@@ -24,11 +24,13 @@ L: rotate the L face clockwise / Shift+L: rotate the L face counterclockwise
 B: rotate the B face clockwise / Shift+B: rotate the B face counterclockwise
 ```
 
-Install dependencies before running lint or build tasks. Execute the following command to run lint.
+Install dependencies before running lint, tests, and build tasks. Execute the following commands to perform these checks.
 
 ```bash
 npm ci
 npm run lint
+npm run test
+npm run build
 ```
 
 This project is released under the [MIT License](LICENSE).
@@ -36,3 +38,7 @@ This project is released under the [MIT License](LICENSE).
 ## GitHub Pages Automatic Deployment
 
 A push to the `main` branch triggers GitHub Actions to build and automatically deploy to GitHub Pages. On first setup, change the repository's "Pages" source to "GitHub Actions". The deployment status can be checked on the "Actions" tab on GitHub, and the page will update a few minutes after completion.
+
+## Lint, Test and Build
+
+The `Lint, Test and Build` GitHub Actions workflow runs on every `pull_request`. It executes `npm run lint`, `npm test`, and `npm run build`. Configure branch protection rules so that merges are blocked until this workflow succeeds.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ L: L面を右回転 / Shift+L: L面を左回転
 B: B面を右回転 / Shift+B: B面を左回転
 ```
 
-Lint やビルドを実行する前には依存関係をインストールしておく必要があります。次の
-コマンドで Lint を実行できます。
+Lint・テスト・ビルドを実行する前には依存関係をインストールしておく必要があります。次の
+コマンドで一連のチェックを実行できます。
 
 ```bash
 npm ci
 npm run lint
+npm run test
+npm run build
 ```
 
 このプロジェクトは [MIT License](LICENSE) の下で公開されています。
@@ -50,10 +52,10 @@ GitHub Pages へ自動デプロイします。初回のみリポジトリ設定�
 "Pages" で公開ソースを "GitHub Actions" に変更してください。
 デプロイの進行状況は GitHub の "Actions" タブから確認でき、完了後数分でページが更新されます。
 
-## Lint とテスト
+## Lint・テスト・ビルド
 
-`pull_request` 発生時に動作する GitHub Actions ワークフロー `Lint and Test` を追加しています。
-`npm run lint` と `npm test` が実行され、成功しないとマージできないようブランチ保護ルールで設定してください。
+`pull_request` 発生時に動作する GitHub Actions ワークフロー `Lint, Test and Build` を追加しています。
+`npm run lint`、`npm test`、`npm run build` が実行され、成功しないとマージできないようブランチ保護ルールで設定してください。
 
 ## ブランチ命名規則
 

--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import { gsap } from 'gsap'
 import Cube from 'cubejs'
 import { COLORS } from '../constants/colors'
-import ICubeRenderer from './ICubeRenderer'
+import type ICubeRenderer from './ICubeRenderer'
 
 interface Orientation {
   'x+': string | null

--- a/rubicsolver-app/src/lib/CubeRenderer2D.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer2D.ts
@@ -1,4 +1,4 @@
-import ICubeRenderer from './ICubeRenderer'
+import type ICubeRenderer from './ICubeRenderer'
 import Cube from 'cubejs'
 
 export default class CubeRenderer2D implements ICubeRenderer {


### PR DESCRIPTION
## 概要
- CI ワークフローに `npm run build` を追加
- 各 README と AGENTS.md を更新してビルド実行を明記

## テスト
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684beec4e2f88321a7e6a13decd80739