### PR TITLE
Switch to 2D display

### DIFF
--- a/rubicsolver-app/src/App.tsx
+++ b/rubicsolver-app/src/App.tsx
@@ -1,4 +1,4 @@
-import RubiksCube from './components/RubiksCube'
+import RubiksCube from './components/RubiksCube2D'
 import './App.css'
 
 function App() {

--- a/rubicsolver-app/tests/appUses2D.test.tsx
+++ b/rubicsolver-app/tests/appUses2D.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import App from '../src/App'
+
+jest.mock('../src/App.css', () => '')
+jest.mock('../src/components/RubiksCube2D', () => () => <div>RubiksCube2DMock</div>)
+
+test('App コンポーネントが RubiksCube2D を表示する', () => {
+  render(<App />)
+  expect(screen.getByText('RubiksCube2DMock')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- 2D 用コンポーネント `RubiksCube2D` をアプリのメイン表示に変更
- `App` が 2D を利用していることを確認するテストを追加

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c034274748321af6f13274b5df1d3