### PR TITLE
Add isometric cube view in 2D renderer

### DIFF
--- a/__tests__/CubeRenderer2D.test.ts
+++ b/__tests__/CubeRenderer2D.test.ts
@@ -11,3 +11,11 @@ it('applyMove 後の状態がモデルと一致する', async () => {
   cube.move('U')
   expect(renderer.getState()).toBe(cube.asString())
 })
+
+it('setCanvas でキャンバスサイズが正しく設定される', () => {
+  const renderer = new CubeRenderer2D()
+  const canvas = document.createElement('canvas')
+  renderer.setCanvas(canvas)
+  expect(canvas.width).toBe(240)
+  expect(canvas.height).toBe(240)
+})

--- a/rubicsolver-app/src/lib/CubeRenderer2D.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer2D.ts
@@ -31,32 +31,93 @@ export default class CubeRenderer2D implements ICubeRenderer {
   }
 
   private draw() {
-    if (!this.ctx || !this.canvas) return
+    if (!this.canvas) return
     const ctx = this.ctx
     const c = this.cell
-    this.canvas.width = c * 12
-    this.canvas.height = c * 9
+    this.canvas.width = c * 8
+    this.canvas.height = c * 8
+    if (!ctx) return
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
+
+    const centerX = this.canvas.width / 2
+    const centerY = c * 3
+    const iso = (x: number, y: number, z: number) => {
+      const ang = Math.PI / 4
+      const ix = (x - z) * Math.cos(ang) * c + centerX
+      const iy = (x + z) * Math.sin(ang) * c - y * c + centerY
+      return { x: ix, y: iy }
+    }
+
+    const drawQuad = (pts: Array<{ x: number; y: number }>, color: string) => {
+      ctx.fillStyle = color
+      ctx.strokeStyle = '#000'
+      ctx.beginPath()
+      ctx.moveTo(pts[0].x, pts[0].y)
+      for (let k = 1; k < pts.length; k++) {
+        ctx.lineTo(pts[k].x, pts[k].y)
+      }
+      ctx.closePath()
+      ctx.fill()
+      ctx.stroke()
+    }
+
     const state = this.cube.asString()
     const faces = state.match(/.{9}/g)!
-    const drawFace = (index: number, ox: number, oy: number) => {
-      const face = faces[index]
+
+    // U face
+    const drawTop = () => {
+      const face = faces[0]
       for (let i = 0; i < 3; i++) {
         for (let j = 0; j < 3; j++) {
           const color = this.colorMap[face[i * 3 + j] as keyof typeof this.colorMap]
-          ctx.fillStyle = color
-          ctx.strokeStyle = '#000'
-          ctx.fillRect(ox + j * c, oy + i * c, c, c)
-          ctx.strokeRect(ox + j * c, oy + i * c, c, c)
+          const p1 = iso(j, 3, i)
+          const p2 = iso(j + 1, 3, i)
+          const p3 = iso(j + 1, 3, i + 1)
+          const p4 = iso(j, 3, i + 1)
+          drawQuad([p1, p2, p3, p4], color)
         }
       }
     }
-    drawFace(0, c * 3, 0)
-    drawFace(4, 0, c * 3)
-    drawFace(2, c * 3, c * 3)
-    drawFace(1, c * 6, c * 3)
-    drawFace(5, c * 9, c * 3)
-    drawFace(3, c * 3, c * 6)
+
+    // F face
+    const drawFront = () => {
+      const face = faces[2]
+      for (let i = 0; i < 3; i++) {
+        for (let j = 0; j < 3; j++) {
+          const color = this.colorMap[face[i * 3 + j] as keyof typeof this.colorMap]
+          const yTop = 3 - i
+          const yBottom = 2 - i
+          const p1 = iso(j, yTop, 3)
+          const p2 = iso(j + 1, yTop, 3)
+          const p3 = iso(j + 1, yBottom, 3)
+          const p4 = iso(j, yBottom, 3)
+          drawQuad([p1, p2, p3, p4], color)
+        }
+      }
+    }
+
+    // R face
+    const drawRight = () => {
+      const face = faces[1]
+      for (let i = 0; i < 3; i++) {
+        for (let j = 0; j < 3; j++) {
+          const color = this.colorMap[face[i * 3 + j] as keyof typeof this.colorMap]
+          const yTop = 3 - i
+          const yBottom = 2 - i
+          const zFront = 3 - j
+          const zBack = 2 - j
+          const p1 = iso(3, yTop, zFront)
+          const p2 = iso(3, yTop, zBack)
+          const p3 = iso(3, yBottom, zBack)
+          const p4 = iso(3, yBottom, zFront)
+          drawQuad([p1, p2, p3, p4], color)
+        }
+      }
+    }
+
+    drawTop()
+    drawFront()
+    drawRight()
   }
 
   async applyMove(move: string) {


### PR DESCRIPTION
## Summary
- 2D描画を展開図から箱型表示に変更
- Canvasサイズをテスト環境でも設定できるように修正
- 対応テストを追加

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cb99ddc4883218b3706a0871c5193