### PR TITLE
Add animation delay and default settings

### DIFF
--- a/rubicsolver-app/src/lib/CubeRenderer.ts
+++ b/rubicsolver-app/src/lib/CubeRenderer.ts
@@ -196,7 +196,7 @@ export default class CubeRenderer implements ICubeRenderer {
         params[axis] = angle
         gsap.to(rotationGroup.rotation, {
           ...params,
-          duration: 0.3,
+          duration: 0.5,
           onComplete: () => {
             rotationGroup.updateMatrixWorld()
             selected.forEach((c) => {

--- a/rubicsolver-app/src/lib/moveExecutor.ts
+++ b/rubicsolver-app/src/lib/moveExecutor.ts
@@ -1,0 +1,17 @@
+import type ICubeRenderer from './ICubeRenderer'
+
+export const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export async function executeMoves(
+  renderer: ICubeRenderer,
+  algorithm: string,
+  interval = 0
+) {
+  const moves = algorithm.split(' ').filter(Boolean)
+  for (let i = 0; i < moves.length; i++) {
+    await renderer.applyMove(moves[i])
+    if (interval > 0 && i < moves.length - 1) {
+      await wait(interval)
+    }
+  }
+}

--- a/rubicsolver-app/tests/cubeRegression.test.tsx
+++ b/rubicsolver-app/tests/cubeRegression.test.tsx
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom'
 import RubiksCube from '../src/components/RubiksCube2D'
 import Cube from 'cubejs'
 
+jest.setTimeout(15000)
+
 jest.mock('gsap', () => ({
   gsap: {
     to: (_target: unknown, { onComplete }: { onComplete?: () => void }) => {
@@ -23,11 +25,17 @@ test('1手回した後にそろえると元に戻る', async () => {
   const input = screen.getByLabelText('手数:') as HTMLInputElement
   fireEvent.change(input, { target: { value: 1 } })
   fireEvent.click(screen.getByText('ランダム'))
-  await waitFor(() => {
-    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
-  })
+  await waitFor(
+    () => {
+      expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+    },
+    { timeout: 5000 }
+  )
   fireEvent.click(screen.getByText('そろえる'))
-  await waitFor(() => {
-    expect(screen.getByTestId('cube-state').textContent).toBe(solved)
-  })
+  await waitFor(
+    () => {
+      expect(screen.getByTestId('cube-state').textContent).toBe(solved)
+    },
+    { timeout: 10000 }
+  )
 })

--- a/rubicsolver-app/tests/defaultValues.test.tsx
+++ b/rubicsolver-app/tests/defaultValues.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import RubiksCube from '../src/components/RubiksCube2D'
+import { DEFAULT_SCRAMBLE_LENGTH as LENGTH2D } from '../src/components/RubiksCube2D'
+import { DEFAULT_SCRAMBLE_LENGTH as LENGTH3D, DEFAULT_CAMERA_POSITION } from '../src/components/RubiksCube'
+
+test('2D版のデフォルト手数が10である', () => {
+  render(<RubiksCube />)
+  const input = screen.getByLabelText('手数:') as HTMLInputElement
+  expect(input.value).toBe(String(LENGTH2D))
+})
+
+test('3D版のデフォルト手数定数が10である', () => {
+  expect(LENGTH3D).toBe(10)
+})
+
+test('カメラ位置定数が期待通り', () => {
+  expect(DEFAULT_CAMERA_POSITION).toEqual([5, 4, 5])
+})

--- a/rubicsolver-app/tests/executeMoves.test.ts
+++ b/rubicsolver-app/tests/executeMoves.test.ts
@@ -1,0 +1,23 @@
+import { executeMoves } from '../src/lib/moveExecutor'
+import type ICubeRenderer from '../src/lib/ICubeRenderer'
+
+jest.useFakeTimers()
+
+test('intervalを指定すると待機する', async () => {
+  const renderer: ICubeRenderer = {
+    applyMove: jest.fn().mockResolvedValue(undefined),
+    getState: () => '',
+    reset: () => {},
+    dispose: () => {}
+  }
+  const p = executeMoves(renderer, 'U R', 1000)
+  await Promise.resolve()
+  expect((renderer.applyMove as jest.Mock).mock.calls).toHaveLength(1)
+  jest.advanceTimersByTime(999)
+  await Promise.resolve()
+  expect((renderer.applyMove as jest.Mock).mock.calls).toHaveLength(1)
+  jest.advanceTimersByTime(1)
+  await Promise.resolve()
+  expect((renderer.applyMove as jest.Mock).mock.calls).toHaveLength(2)
+  await p
+})


### PR DESCRIPTION
## Summary
- カメラ位置を少し下げるため定数 `DEFAULT_CAMERA_POSITION` を導入
- スクランブル手数の初期値を 10 に変更
- キューブ回転のアニメーション時間を 0.5 秒に延長
- 解法実行時は 1 秒間隔で回転するよう `executeMoves` を追加
- テストを更新し新しい定数や待機処理を検証

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cbda1332c8321a5126ce1cf04fa14