### PR TITLE
Add 2D cube rotation animation and display solution steps

### DIFF
--- a/rubicsolver-app/tests/solutionSteps.test.tsx
+++ b/rubicsolver-app/tests/solutionSteps.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import RubiksCube from '../src/components/RubiksCube2D'
+import Cube from 'cubejs'
+
+jest.setTimeout(10000)
+
+jest.mock('gsap', () => ({
+  gsap: {
+    to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  },
+  to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+    if (onComplete) onComplete()
+    return {}
+  }
+}))
+
+ test('そろえるボタン押下で手順が表示される', async () => {
+  Cube.initSolver()
+  render(<RubiksCube />)
+  const input = screen.getByLabelText('手数:') as HTMLInputElement
+  fireEvent.change(input, { target: { value: 1 } })
+  fireEvent.click(screen.getByText('ランダム'))
+  await waitFor(() => {
+    const solved = new Cube().asString()
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+  })
+  fireEvent.click(screen.getByText('そろえる'))
+  await waitFor(() => {
+    expect(screen.getByTestId('solution-steps')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- 2D版レンダラーをキュービーレベルで管理し、回転アニメーションを実装
- "そろえる" 実行時に手順を表示し、現在の手順を赤色で強調表示
- スクランブルやリセット時に手順表示をクリア
- 上記機能を確認するテストを追加

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cc1f3d41c83219a9a7742c68239ad