### PR TITLE
Add solution explanation feature

### DIFF
--- a/rubicsolver-app/src/components/RubiksCube2D.tsx
+++ b/rubicsolver-app/src/components/RubiksCube2D.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHand
 import CubeRenderer2D from '../lib/CubeRenderer2D'
 import CubeController, { generateScramble } from '../lib/CubeController'
 import { executeMoves, wait } from '../lib/moveExecutor'
+import { generateExplanations } from '../lib/solutionExplanation'
 import Cube from 'cubejs'
 
 export const DEFAULT_SCRAMBLE_LENGTH = 10
@@ -18,6 +19,7 @@ function RubiksCube2D(_props: unknown, ref: React.Ref<{
   const [errorMessage, setErrorMessage] = useState('')
   const [cubeState, setCubeState] = useState(controllerRef.current.getState())
   const [solutionSteps, setSolutionSteps] = useState<string[]>([])
+  const [solutionExplanations, setSolutionExplanations] = useState<string[]>([])
   const [currentStep, setCurrentStep] = useState(-1)
   const busyRef = useRef(false)
   const [busy, setBusy] = useState(false)
@@ -70,6 +72,7 @@ function RubiksCube2D(_props: unknown, ref: React.Ref<{
         setCubeState(controllerRef.current.getState())
         setErrorMessage('')
         setSolutionSteps([])
+        setSolutionExplanations([])
         setCurrentStep(-1)
       } catch (err) {
         console.error(err)
@@ -85,6 +88,7 @@ function RubiksCube2D(_props: unknown, ref: React.Ref<{
       setScramble('')
       setCubeState(controllerRef.current.getState())
       setSolutionSteps([])
+      setSolutionExplanations([])
       setCurrentStep(-1)
     })
   }
@@ -95,6 +99,7 @@ function RubiksCube2D(_props: unknown, ref: React.Ref<{
         const solution = controllerRef.current.solve()
         const moves = solution.split(' ').filter(Boolean)
         setSolutionSteps(moves)
+        setSolutionExplanations(generateExplanations(moves))
         for (let i = 0; i < moves.length; i++) {
           setCurrentStep(i)
           await applyMoveDirect(moves[i])
@@ -104,6 +109,7 @@ function RubiksCube2D(_props: unknown, ref: React.Ref<{
         }
         setCurrentStep(-1)
         setSolutionSteps([])
+        setSolutionExplanations([])
         setCubeState(controllerRef.current.getState())
         setErrorMessage('')
       } catch (err) {
@@ -170,20 +176,27 @@ B: B面を右回転 / Shift+B: B面を左回転
         </details>
         <div style={{ marginTop: 8 }}>スクランブル: {scramble}</div>
         {solutionSteps.length > 0 && (
-          <div data-testid="solution-steps" style={{ marginTop: 8 }}>
-            {solutionSteps.map((s, idx) => (
-              <span
-                key={idx}
-                style={{
-                  marginRight: 4,
-                  color: idx === currentStep ? 'red' : undefined,
-                  fontWeight: idx === currentStep ? 'bold' : undefined
-                }}
-              >
-                {s}
-              </span>
-            ))}
-          </div>
+          <>
+            <div data-testid="solution-steps" style={{ marginTop: 8 }}>
+              {solutionSteps.map((s, idx) => (
+                <span
+                  key={idx}
+                  style={{
+                    marginRight: 4,
+                    color: idx === currentStep ? 'red' : undefined,
+                    fontWeight: idx === currentStep ? 'bold' : undefined
+                  }}
+                >
+                  {s}
+                </span>
+              ))}
+            </div>
+            {currentStep >= 0 && (
+              <div data-testid="solution-explanation" style={{ marginTop: 4 }}>
+                {solutionExplanations[currentStep]}
+              </div>
+            )}
+          </>
         )}
         <div data-testid="cube-state" style={{ display: 'none' }}>
           {cubeState}

--- a/rubicsolver-app/src/lib/solutionExplanation.ts
+++ b/rubicsolver-app/src/lib/solutionExplanation.ts
@@ -1,0 +1,23 @@
+export function moveToExplanation(move: string): string {
+  const faceMap: Record<string, string> = {
+    U: '上面',
+    D: '下面',
+    L: '左面',
+    R: '右面',
+    F: '前面',
+    B: '背面'
+  }
+  const face = faceMap[move[0]] || ''
+  const modifier = move.slice(1)
+  let rotation = '時計回りに回してブロックを移動する'
+  if (modifier === "'") {
+    rotation = '反時計回りに回してブロックを移動する'
+  } else if (modifier === '2') {
+    rotation = '2回回してブロックを移動する'
+  }
+  return `${face}を${rotation}`
+}
+
+export function generateExplanations(moves: string[]): string[] {
+  return moves.map(moveToExplanation)
+}

--- a/rubicsolver-app/tests/solutionExplanation.test.tsx
+++ b/rubicsolver-app/tests/solutionExplanation.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import RubiksCube from '../src/components/RubiksCube2D'
+import Cube from 'cubejs'
+
+jest.setTimeout(10000)
+
+jest.mock('gsap', () => ({
+  gsap: {
+    to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  },
+  to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+    if (onComplete) onComplete()
+    return {}
+  }
+}))
+
+ test('そろえる実行時に解説文が表示される', async () => {
+  Cube.initSolver()
+  render(<RubiksCube />)
+  const input = screen.getByLabelText('手数:') as HTMLInputElement
+  fireEvent.change(input, { target: { value: 1 } })
+  fireEvent.click(screen.getByText('ランダム'))
+  await waitFor(() => {
+    const solved = new Cube().asString()
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+  })
+  fireEvent.click(screen.getByText('そろえる'))
+  await waitFor(() => {
+    expect(screen.getByTestId('solution-explanation')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- 解法手順に対応した日本語の解説文を表示できるようにしました
- `generateExplanations` 関数を追加し、手順から解説文へ変換します
- 手順表示中に現在のステップに合わせて解説文を表示します
- 解説文が表示されることを確認するテストを追加しました

## Testing
- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d0a657fdc83219f4e26e91ce20a9f