### PR TITLE
解法手順を進行中に表示

### DIFF
--- a/rubicsolver-app/tests/algorithmProgress.test.tsx
+++ b/rubicsolver-app/tests/algorithmProgress.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import RubiksCube from '../src/components/RubiksCube2D'
+import Cube from 'cubejs'
+
+jest.setTimeout(10000)
+
+jest.mock('gsap', () => ({
+  gsap: {
+    to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+      if (onComplete) onComplete()
+      return {}
+    }
+  },
+  to: (_: unknown, { onComplete }: { onComplete?: () => void }) => {
+    if (onComplete) onComplete()
+    return {}
+  }
+}))
+
+test('揃え中に手順ハイライトが表示される', async () => {
+  Cube.initSolver()
+  render(<RubiksCube />)
+  const input = screen.getByLabelText('手数:') as HTMLInputElement
+  fireEvent.change(input, { target: { value: 1 } })
+  fireEvent.click(screen.getByText('ランダム'))
+  await waitFor(() => {
+    const solved = new Cube().asString()
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+  })
+  fireEvent.click(screen.getByText('そろえる'))
+  await waitFor(() => {
+    const items = screen.getAllByRole('listitem')
+    expect(items.some((li) => li.style.fontWeight === 'bold')).toBe(true)
+  })
+})


### PR DESCRIPTION
## 概要
- 解法中も手順一覧を表示し、現在の手順をハイライトするよう更新
- 手順ごとに実行される操作を表示
- 上記機能を確認するテストを追加

## テスト結果
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d29c4194c83219e1b8641eea90b37