### PR TITLE
Add manual solve control

### DIFF
--- a/rubicsolver-app/tests/cubeRegression.test.tsx
+++ b/rubicsolver-app/tests/cubeRegression.test.tsx
@@ -32,6 +32,10 @@ test('1手回した後にそろえると元に戻る', async () => {
     { timeout: 5000 }
   )
   fireEvent.click(screen.getByText('そろえる'))
+  await waitFor(() => {
+    expect(screen.getByText('自動でそろえる')).toBeInTheDocument()
+  })
+  fireEvent.click(screen.getByText('自動でそろえる'))
   await waitFor(
     () => {
       expect(screen.getByTestId('cube-state').textContent).toBe(solved)

--- a/rubicsolver-app/tests/manualSolve.test.tsx
+++ b/rubicsolver-app/tests/manualSolve.test.tsx
@@ -18,20 +18,26 @@ jest.mock('gsap', () => ({
   }
 }))
 
- test('そろえる実行時に解説文が表示される', async () => {
+test('一手すすめるで段階的に解法を実行できる', async () => {
   Cube.initSolver()
   render(<RubiksCube />)
   const input = screen.getByLabelText('手数:') as HTMLInputElement
   fireEvent.change(input, { target: { value: 1 } })
   fireEvent.click(screen.getByText('ランダム'))
   await waitFor(() => {
-    const solved = new Cube().asString()
-    expect(screen.getByTestId('cube-state').textContent).not.toBe(solved)
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(new Cube().asString())
   })
   fireEvent.click(screen.getByText('そろえる'))
   await waitFor(() => {
-    expect(screen.getByText('自動でそろえる')).toBeInTheDocument()
+    expect(screen.getByText('一手すすめる')).toBeInTheDocument()
+  })
+  const before = screen.getByTestId('cube-state').textContent
+  fireEvent.click(screen.getByText('一手すすめる'))
+  await waitFor(() => {
+    expect(screen.getByTestId('cube-state').textContent).not.toBe(before)
   })
   fireEvent.click(screen.getByText('自動でそろえる'))
-  await screen.findByTestId('solution-explanation')
+  await waitFor(() => {
+    expect(screen.getByTestId('cube-state').textContent).toBe(new Cube().asString())
+  })
 })

--- a/rubicsolver-app/tests/solutionSteps.test.tsx
+++ b/rubicsolver-app/tests/solutionSteps.test.tsx
@@ -32,4 +32,6 @@ jest.mock('gsap', () => ({
   await waitFor(() => {
     expect(screen.getByTestId('solution-steps')).toBeInTheDocument()
   })
+  expect(screen.getByText('一手すすめる')).toBeInTheDocument()
+  expect(screen.getByText('自動でそろえる')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- そろえるボタン押下後に一手ずつ進める・自動で揃える機能を追加
- 3D/2Dコンポーネントに手動解法処理を実装
- 新機能に対応したテストを更新
- 手動解法のテストを追加

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d27b8c9b88321b7b94afc25db8fef